### PR TITLE
Update google formatter action to use Java 17

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+       - uses: actions/setup-java@v2
+         with:
+           java-version: 17
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--skip-sorting-imports --replace"


### PR DESCRIPTION
# Description

Updated the Google Java formatter version to use Java JDK 17 instead of Java JDK 11

Fixes #33 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have performed tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
