### PR TITLE
Fix cutting of lines too short in formatter

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,4 +23,4 @@ jobs:
           distribution: 'oracle'
       - uses: axel-op/googlejavaformat-action@v3
         with:
-          args: "--skip-sorting-imports --replace --length=120"
+          args: "--skip-sorting-imports --replace --length 120"


### PR DESCRIPTION
# Description

Increased max line length to 120 because the formatter is cutting lines to short

Fixes #30 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This will be tested in a PR that has a line ~120 characters and that's going to either main or 2024-beta

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have performed tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
